### PR TITLE
Handle unsorted spectra.

### DIFF
--- a/bin/library_search/conda_env_gnps_new.yml
+++ b/bin/library_search/conda_env_gnps_new.yml
@@ -6,6 +6,8 @@ dependencies:
   - pandas
   - numpy=1.24.3
   - numba=0.58.1
+  - pytest
+  - pip
   - pip:
     - xmltodict
     - requests
@@ -13,3 +15,5 @@ dependencies:
     - tqdm
     - pyteomics
     - lxml
+    - pytest
+    - importlib-metadata

--- a/bin/library_search/gnps_new/entropy.py
+++ b/bin/library_search/gnps_new/entropy.py
@@ -188,7 +188,8 @@ def entropy_similarity(qry_spec: np.ndarray, ref_spec: np.ndarray,
                        min_matched_peak: int = 1,
                        sqrt_transform: bool = False,  # Unused
                        penalty: float = 0.,
-                       shift: float = 0.0):
+                       shift: float = 0.0,
+                       require_sorted:bool = False) -> Tuple[float, int]:
     """
     Calculate similarity between two spectra.
 
@@ -206,6 +207,15 @@ def entropy_similarity(qry_spec: np.ndarray, ref_spec: np.ndarray,
         Penalty for unmatched peaks. If set to 0, traditional cosine score; if set to 1, traditional reverse cosine score.
     shift: float
         Shift for m/z values. If not 0, hybrid search is performed. shift = prec_mz(qry) - prec_mz(ref)
+    require_sorted: bool
+        If True, requires spectra sorted by m/z. If False, sorts the spectra by m/z if needed.
+    
+    Returns
+    -------
+    score: float
+        Similarity score between 0 and 1.
+    n_matches: int
+        Number of matched peaks.
     """
     tolerance = np.float32(tolerance)
     penalty = np.float32(penalty)
@@ -213,6 +223,17 @@ def entropy_similarity(qry_spec: np.ndarray, ref_spec: np.ndarray,
 
     if qry_spec.size == 0 or ref_spec.size == 0:
         return 0.0, 0
+    
+    if require_sorted:
+        if not np.all(qry_spec[:, 0][:-1] <= qry_spec[:, 0][1:]):   # True for array of shape [1,2]
+            raise ValueError("Query spectrum is not sorted by m/z.")
+        if not np.all(ref_spec[:, 0][:-1] <= ref_spec[:, 0][1:]):
+            raise ValueError("Reference spectrum is not sorted by m/z.")
+    else:
+        if not np.all(qry_spec[:, 0][:-1] <= qry_spec[:, 0][1:]):
+            qry_spec = qry_spec[np.argsort(qry_spec[:, 0])]
+        if not np.all(ref_spec[:, 0][:-1] <= ref_spec[:, 0][1:]):
+            ref_spec = ref_spec[np.argsort(ref_spec[:, 0])]
 
     # normalize the intensity
     ref_spec[:, 1] /= np.sum(ref_spec[:, 1])

--- a/bin/library_search/gnps_new/test_cosine.py
+++ b/bin/library_search/gnps_new/test_cosine.py
@@ -1,0 +1,53 @@
+import pytest
+import numpy as np
+from .cosine import cosine_similarity
+
+def test_cosine_similarity_standard():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = cosine_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0)
+    print(f"Standard Score: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.2499243052576287)
+    assert n_matches == 1
+
+def test_cosine_similarity_penalty():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = cosine_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0.6)
+    print(f"Penalty Score: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.3387793425447733)
+    assert n_matches == 1
+
+def test_cosine_similarity_with_shift():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = cosine_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0.6, shift=10)
+    print(f"Enhanced Reverse Score with Shift: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.6719727183775544)
+    assert n_matches == 2
+
+def test_cosine_similarity_empty_spectra():
+    peaks1 = np.array([], dtype=np.float32).reshape(0, 2)
+    peaks2 = np.array([], dtype=np.float32).reshape(0, 2)
+    score, n_matches = cosine_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0)
+    assert score == 0.0
+    assert n_matches == 0
+
+def test_cosine_similarity_unsorted_spectra():
+    unsorted_peaks1 = np.array([[100, 50.0], [80, 50.0], [60, 100.0], [50, 8.0]], dtype=np.float32)
+    unsorted_peaks2 = np.array([[90, 100.0], [80, 66.0], [70, 50.0], [55, 38.0]], dtype=np.float32)
+    unsorted_score, unsorted_n_matches = cosine_similarity(unsorted_peaks1, unsorted_peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=False)
+    sorted_peaks1   = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    sorted_peaks2   = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    sorted_score, sorted_n_matches = cosine_similarity(sorted_peaks1, sorted_peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=True)
+    print(f"Unsorted Score: {unsorted_score:.3f}, Matches: {unsorted_n_matches}")
+    print(f"Sorted Score: {sorted_score:.3f}, Matches: {sorted_n_matches}")
+    assert pytest.approx(unsorted_score, 0.2499243052576287) == sorted_score
+    assert unsorted_n_matches == sorted_n_matches
+    assert unsorted_score == sorted_score
+
+def test_cosine_similarity_sorted_requirement():
+    peaks1 = np.array([[100, 50.0], [80, 50.0], [60, 100.0], [50, 8.0]], dtype=np.float32)
+    peaks2 = np.array([[90, 100.0], [80, 66.0], [70, 50.0], [55, 38.0]], dtype=np.float32)
+    with pytest.raises(ValueError):
+        cosine_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=True)

--- a/bin/library_search/gnps_new/test_entropy.py
+++ b/bin/library_search/gnps_new/test_entropy.py
@@ -1,0 +1,53 @@
+import pytest
+import numpy as np
+from .entropy import entropy_similarity
+
+def test_entropy_similarity_standard():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = entropy_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0)
+    print(f"Standard Score: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.26056383550167084)
+    assert n_matches == 1
+
+def test_entropy_similarity_penalty():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = entropy_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0.6)
+    print(f"Penalty Score: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.3425292372703552)
+    assert n_matches == 1
+
+def test_entropy_similarity_with_shift():
+    peaks1 = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    peaks2 = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    score, n_matches = entropy_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0.6, shift=10)
+    print(f"Enhanced Reverse Score with Shift: {score:.3f}, Matches: {n_matches}")
+    assert score == pytest.approx(0.6542002707719803)
+    assert n_matches == 2
+
+def test_entropy_similarity_empty_spectra():
+    peaks1 = np.array([], dtype=np.float32).reshape(0, 2)
+    peaks2 = np.array([], dtype=np.float32).reshape(0, 2)
+    score, n_matches = entropy_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0)
+    assert score == 0.0
+    assert n_matches == 0
+
+def test_entropy_similarity_unsorted_spectra():
+    unsorted_peaks1 = np.array([[100, 50.0], [80, 50.0], [60, 100.0], [50, 8.0]], dtype=np.float32)
+    unsorted_peaks2 = np.array([[90, 100.0], [80, 66.0], [70, 50.0], [55, 38.0]], dtype=np.float32)
+    unsorted_score, unsorted_n_matches = entropy_similarity(unsorted_peaks1, unsorted_peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=False)
+    sorted_peaks1   = np.array([[50, 8.0], [60, 100.0], [80, 50.0], [100, 50.0]], dtype=np.float32)
+    sorted_peaks2   = np.array([[55, 38.0], [70, 50.0], [80, 66.0], [90, 100.0]], dtype=np.float32)
+    sorted_score, sorted_n_matches = entropy_similarity(sorted_peaks1, sorted_peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=True)
+    print(f"Unsorted Score: {unsorted_score:.3f}, Matches: {unsorted_n_matches}")
+    print(f"Sorted Score: {sorted_score:.3f}, Matches: {sorted_n_matches}")
+    assert pytest.approx(unsorted_score, 0.2499243052576287) == sorted_score
+    assert unsorted_n_matches == sorted_n_matches
+    assert unsorted_score == sorted_score
+
+def test_entropy_similarity_sorted_requirement():
+    peaks1 = np.array([[100, 50.0], [80, 50.0], [60, 100.0], [50, 8.0]], dtype=np.float32)
+    peaks2 = np.array([[90, 100.0], [80, 66.0], [70, 50.0], [55, 38.0]], dtype=np.float32)
+    with pytest.raises(ValueError):
+        entropy_similarity(peaks1, peaks2, tolerance=0.05, sqrt_transform=True, penalty=0, require_sorted=True)


### PR DESCRIPTION
The goal of this PR is to handle undefined behavior for unsorted spectra which was discovered when reusing this code [here](https://github.com/Wang-Bioinformatics-Lab/IDBac-KB-Server/commit/09395805025c99c7ec5ad901be575428e2378842).

Currently, if peaks are not sorted, the wrong result is returned. I have added behavior to either 1) check if peaks are sorted in linear time or 2) automatically sort the peaks by m/z (default behavior).

Tests are implemented in 
* [bin/library_search/gnps_new/cosine.py](https://github.com/Wang-Bioinformatics-Lab/NextflowModules/compare/Resilience?expand=1#diff-473e501dbecef57c67a8c5b1c578a7093bcb6b1c4afddb06910701c63039975c)
* [bin/library_search/gnps_new/test_entropy.py](https://github.com/Wang-Bioinformatics-Lab/NextflowModules/compare/Resilience?expand=1#diff-48a25269a03c9c2d00ef7340e32c5d96f435e52b2f26478c320951d65156b962)

which compare the unsorted behavior against sorted behavior.
