### PR TITLE
Fix library search

### DIFF
--- a/bin/library_search/gnps_new/file_io.py
+++ b/bin/library_search/gnps_new/file_io.py
@@ -15,8 +15,8 @@ def batch_process_queries(qry_file, min_peak, batch_size=1000):
     if file_format == '.mzml':
         with mzml.MzML(qry_file) as reader:
             for spectrum in reader:
-                if spectrum['ms level'] == 2:  # MS2 scans only
-                    try:
+                try:
+                    if spectrum['ms level'] == 2:  # MS2 scans only
                         precursor_mz = float(
                             spectrum['precursorList']['precursor'][0]['selectedIonList']['selectedIon'][0][
                                 'selected ion m/z'])
@@ -66,14 +66,14 @@ def batch_process_queries(qry_file, min_peak, batch_size=1000):
                             yield batch_specs, np.array(batch_prec_mzs)
                             batch_specs = []
                             batch_prec_mzs = []
-                    except:
-                        continue
+                except:
+                    continue
 
     elif file_format == '.mzxml':
         with mzxml.MzXML(qry_file) as reader:
             for spectrum in reader:
-                if spectrum['msLevel'] == 2:  # MS2 scans only
-                    try:
+                try:
+                    if spectrum['msLevel'] == 2:  # MS2 scans only
                         precursor_mz = float(spectrum['precursorMz'][0]['precursorMz'])
 
                         mz_array = np.array(spectrum['m/z array'])
@@ -118,8 +118,8 @@ def batch_process_queries(qry_file, min_peak, batch_size=1000):
                             yield batch_specs, np.array(batch_prec_mzs)
                             batch_specs = []
                             batch_prec_mzs = []
-                    except:
-                        continue
+                except:
+                    continue
 
     elif file_format == '.mgf':
         scan_idx = 0

--- a/nf_library_search_modules.nf
+++ b/nf_library_search_modules.nf
@@ -115,8 +115,8 @@ process searchDataGNPSNew{
     mkdir -p search_results
 
     python $params.TOOL_FOLDER/gnps_new/main_search.py \
-        --gnps_lib_mgf "$input_library" \
-        --qry_file "$input_spectrum" \
+        --gnps_lib_mgf $input_library \
+        --qry_file $input_spectrum \
         --algorithm $search_algorithm \
         --analog_search $analog_search \
         --analog_max_shift $analog_max_shift \
@@ -155,7 +155,7 @@ process searchDataBlink {
     echo \$previous_cwd
 
     cd $params.TOOL_FOLDER/blink && python -m blink.blink_cli \
-    $input_spectrum_abs \
+    "$input_spectrum_abs" \
     $input_library_abs \
     \$previous_cwd/search_results/${randomFilename}.csv \
     $params.TOOL_FOLDER/blink/models/positive_random_forest.pickle \


### PR DESCRIPTION
Workflow fails on files with “ “ in its filename
- Searchtool=gnps_indexed (FAILED) https://gnps2.org/status?task=1a7de4533a0147f980f6d5b88e036e1e
- Searchtool=gnps (DONE) https://gnps2.org/status?task=cbaffcf3fcfd4588ba55eb2a81558d19
- Searchtool=gnps_new (FAILED) https://gnps2.org/status?task=eb2427a6a2224ea2a49a2e30a33d6239
- Searchtool=blink (FAILED) https://gnps2.org/status?task=a7acc4f56f1f42b08d52a31c0586d792

Summary: All fails except for searchtool=gnps

Fixes: 
- Unquote input file in Nextflowmodules 
- Fixed key errors in blink

Results (on beta):
- Searchtool=gnps_indexed (DONE) https://beta.gnps2.org/status?task=97a66d6877d44f248465b41a4468caac 
- Searchtool=gnps (DONE) https://beta.gnps2.org/status?task=dfc24b593ad54d16831537b9a3fbf4a6 
- Searchtool=gnps_new (DONE) https://beta.gnps2.org/status?task=cd4b271044214f4ebc79f3ad65c2a959 
- Searchtool=blink (FAILED) https://beta.gnps2.org/status?task=349ead748a2f4ff4a40cc6c1b28c08fc 

Notes:
- Blink still fails, but likely due to other issues such as memory limits (exitcode=137). FileNotFound error is fixed.

