### PR TITLE
Handle corrupt files

### DIFF
--- a/bin/library_search/library_search_indexed.py
+++ b/bin/library_search/library_search_indexed.py
@@ -398,14 +398,18 @@ def main():
 
     
     args = parser.parse_args()
-    # print("starting to read files", args.spectrum_file, args.library_file)
-    # start_time = time.time()
-    spectrum_mgf = read_file(args.spectrum_file)
-    # print(len(spectrum_mgf))
-    library_mgf = read_file(args.library_file)
-    # print("Reading the files took:", time.time() - start_time, "seconds")
-    # start_time = time.time()
-    
+    try:
+        # print("starting to read files", args.spectrum_file, args.library_file)
+        # start_time = time.time()
+        spectrum_mgf = read_file(args.spectrum_file)
+        # print(len(spectrum_mgf))
+        library_mgf = read_file(args.library_file)
+        # print("Reading the files took:", time.time() - start_time, "seconds")
+        # start_time = time.time()
+    except Exception as e:
+        print("Not able to read the input files. Exiting.", e)
+        sys.exit(0)
+        
     if len(spectrum_mgf) == 0 or len(library_mgf) == 0:
         print("No spectra found in the input files. Exiting.")
         sys.exit(0)


### PR DESCRIPTION
Issue:
- workflow failure https://gnps2.org/status?task=4a2a2ab3c26444b99a2974137e6178bd
- error message implies corrupt input file (wrong base64 encoding)
```Command error:
  Traceback (most recent call last):
    File "/app/workflows_user/librarysearch_workflow/bin/NextflowModules/bin/library_search/library_search_indexed.py", line 482, in <module>
      main()
    File "/app/workflows_user/librarysearch_workflow/bin/NextflowModules/bin/library_search/library_search_indexed.py", line 403, in main
      spectrum_mgf = read_file(args.spectrum_file)
    File "/app/workflows_user/librarysearch_workflow/bin/NextflowModules/bin/library_search/library_search_indexed.py", line 373, in read_file
      return read_mzml_spectrum(file_path)
    File "/app/workflows_user/librarysearch_workflow/bin/NextflowModules/bin/library_search/library_search_indexed.py", line 288, in read_mzml_spectrum
      for spectrum in reader:
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/auxiliary/file_helpers.py", line 178, in __next__
      return next(self._reader)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/xml.py", line 1245, in __next__
      return next(self._iterator)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/xml.py", line 1312, in _yield_from_index
      yield self.parser.get_by_id(key, **self.config)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/auxiliary/file_helpers.py", line 84, in wrapped
      return func(self, *args, **kwargs)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/xml.py", line 1153, in get_by_id
      data = self._get_info_smart(elem, **kwargs)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/mzml.py", line 327, in _get_info_smart
      info = self._get_info(element,
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/xml.py", line 432, in _get_info
      info[cname] = self._get_info_smart(child, ename=cname, **kwargs)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/mzml.py", line 327, in _get_info_smart
      info = self._get_info(element,
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/xml.py", line 435, in _get_info
      self._get_info_smart(child, ename=cname, **kwargs))
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/mzml.py", line 331, in _get_info_smart
      info = self._handle_binary(info, **kwargs)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/mzml.py", line 308, in _handle_binary
      array = self.decode_data_array(binary, compressed, dtype)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/auxiliary/utils.py", line 283, in decode_data_array
      binary = self._base64_decode(source)
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/site-packages/pyteomics/auxiliary/utils.py", line 248, in _base64_decode
      decoded_source = base64.b64decode(source.encode('ascii'))
    File "/app/launchserver/env/conda_envs/conda_env-6b2ccd14514de51b205c4abedfee9fe4/lib/python3.8/base64.py", line 87, in b64decode
      return binascii.a2b_base64(s)
  binascii.Error: Incorrect padding
```

Fix:
- wrap `read_file` with try-except
- exit if file cannot be read
- test result (DONE): https://beta.gnps2.org/status?task=0a467fffe3084fd0946fc2c412aee6b8