### PR TITLE
Do not skip scans based on common 'TITLE' or 'SCANS' values.

### DIFF
--- a/bin/library_search/library_summary.py
+++ b/bin/library_search/library_summary.py
@@ -1,23 +1,43 @@
 from pyteomics import mgf
 import argparse
-import sys
-import os
-import glob
 import pandas as pd
+import logging
 
 def main():
     parser = argparse.ArgumentParser(description='Generate a summary of a library')
     parser.add_argument('library', help='library file')
     parser.add_argument('output_summary')
+    parser.add_argument('--debug', action='store_true')
 
     args = parser.parse_args()
 
+    if args.debug:
+        # No practical use for now, but here for posterity
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
     output_list = []
 
-    with mgf.MGF(args.library) as reader:
+    seen_titles = set()
+    seen_scans  = set()
+
+    no_scan_err_shown   = False
+    dup_scan_err_shown  = False
+
+    # use_index=False means no requirement for title or scan number uniqueness from Pyteomics
+    # To protect downstream processes, spectrum_id is checked for presence and uniqueness
+    # Duplicate scan numbers are ignored as they're not included in output
+    with mgf.read(args.library, use_index=False) as reader: 
         for spectrum in reader:
             # We will use the spectrum ID as the key for the dictionary
             spectrum_id = spectrum['params'].get('spectrumid', spectrum['params'].get('title', "No ID"))
+            if spectrum_id == "No ID":
+                raise ValueError(f"Spectrum in '{args.library}' has no 'TITLE' and no 'SPECTRUMID' attribute.")
+            if spectrum_id in seen_titles:
+                raise ValueError(f"Spectrum in '{args.library}' has duplicate 'TITLE' or 'SPECTRUMID': '{spectrum_id}'")
+            seen_titles.add(spectrum_id)
+
             compound_name = spectrum['params'].get('compound_name', spectrum['params'].get("name", "No Compound"))
             smiles = spectrum['params'].get('smiles', "")
             collision_energy = spectrum['params'].get('collision_energy', 0)
@@ -25,6 +45,16 @@ def main():
             ion_source = spectrum['params'].get('ion_source', "")
             charge = spectrum['params'].get('charge', 0)
             adduct = spectrum['params'].get('adduct', "NA")
+            
+            scan = spectrum['params'].get('scans')
+            if not scan and not no_scan_err_shown:
+                logging.warning("An MGF entry with no scan number was found in '%s'", args.library)
+                no_scan_err_shown = True
+            if scan and scan in seen_scans and not dup_scan_err_shown:
+                logging.warning("A duplicate scan number ('%s') was found in '%s'", str(scan), args.library)
+                dup_scan_err_shown = True
+            seen_scans.add(scan)
+
             try:
                 precursormz = spectrum['params'].get('pepmass', [0])[0]
             except:
@@ -45,6 +75,9 @@ def main():
 
     # creating an output df
     output_df = pd.DataFrame(output_list)
+    if output_df.empty:
+        # Create an empty DataFrame with the correct columns
+        output_df = pd.DataFrame(columns=["spectrum_id", "compound_name", "smiles", "collision_energy", "instrument", "ion_source", "charge", "adduct", "precursormz"])
     output_df.to_csv(args.output_summary, sep="\t", index=False)
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Warn users of missing or duplicate scan numbers.
* Raise error for duplicate title or spectrumid values (whichever is output to the summary).